### PR TITLE
zdtm: shm test update

### DIFF
--- a/test/zdtm.sh
+++ b/test/zdtm.sh
@@ -7,7 +7,6 @@ static/pipe00
 static/busyloop00
 static/cwd00
 static/env00
-static/shm
 static/maps00
 static/mprotect00
 static/mtime_mmap
@@ -39,6 +38,7 @@ static/utsname
 
 IPC_TEST_LIST="
 static/ipc_namespace
+static/shm
 "
 
 CRTOOLS=`pwd`/`dirname $0`/../crtools

--- a/test/zdtm/live/static/Makefile
+++ b/test/zdtm/live/static/Makefile
@@ -145,6 +145,7 @@ socket_aio:		override LDLIBS += -lrt
 unlink_largefile:	override CFLAGS += -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE
 inotify_system_nodel:	override CFLAGS += -DNODEL
 pthread00:		override LDLIBS += -pthread
+shm:			override CFLAGS += -DNEW_IPC_NS
 
 $(LIB):	force
 	$(MAKE) -C $(LIBDIR)

--- a/test/zdtm/live/static/shm.c
+++ b/test/zdtm/live/static/shm.c
@@ -1,3 +1,6 @@
+#define _GNU_SOURCE
+#include <sched.h>
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -12,7 +15,7 @@
 #include "zdtmtst.h"
 
 const char *test_doc="Tests detached shmems migrate fine";
-const char *test_author="Andrew Vagin <avagin@parallels.com>";
+const char *test_author="Stanislav Kinsbursky <skinsbursky@parallels.com>";
 
 #define DEF_MEM_SIZE	(40960)
 unsigned int shmem_size = DEF_MEM_SIZE;
@@ -20,69 +23,166 @@ TEST_OPTION(shmem_size, uint, "Size of shared memory segment", 0);
 
 #define INIT_CRC	(~0)
 
-int main(int argc, char **argv)
+char *filename;
+
+static int fill_shm_seg(int id, size_t size)
+{
+	uint8_t *mem;
+	uint32_t crc = INIT_CRC;
+
+	mem = shmat(id, NULL, 0);
+	if (mem == (void *)-1) {
+		err("Can't attach shm: %d\n", -errno);
+		return -1;
+	}
+
+	datagen(mem, size, &crc);
+
+	if (shmdt(mem) < 0) {
+		err("Can't detach shm: %d\n", -errno);
+		return -1;
+	}
+	return 0;
+}
+
+static int get_shm_seg(int key, size_t size, unsigned int flags)
+{
+	int id;
+
+	id = shmget(key, size, 0777 | flags);
+	if (id == -1) {
+		err("Can't get shm: %d\n", -errno);
+		return -1;
+	}
+	return id;
+}
+
+static int prepare_shm(int key, size_t size)
+{
+	int id;
+
+	id = get_shm_seg(key, shmem_size, IPC_CREAT | IPC_EXCL);
+	if (id == -1) {
+		return -1;
+	}
+	if (fill_shm_seg(id, shmem_size) < 0)
+		return -1;
+	return id;
+}
+
+static int check_shm_id(int id, size_t size)
+{
+	uint8_t *mem;
+	uint32_t crc = INIT_CRC;
+
+	mem = shmat(id, NULL, 0);
+	if (mem == (void *)-1) {
+		err("Can't attach shm: %d\n", -errno);
+		return -1;
+	}
+	crc = INIT_CRC;
+	if (datachk(mem, size, &crc)) {
+		fail("shmem data are corrupted");
+		return -1;
+	}
+	if (shmdt(mem) < 0) {
+		err("Can't detach shm: %d\n", -errno);
+		return -1;
+	}
+	return 0;
+}
+
+static int check_shm_key(int key, size_t size)
+{
+	int id;
+
+	id = get_shm_seg(key, size, 0);
+	if (id < 0)
+		return -1;
+	return check_shm_id(id, size);
+}
+
+static void test_fn(void)
 {
 	key_t key;
 	int shm;
 	int fail_count = 0;
-	uint8_t *mem;
-	uint32_t crc;
 	int ret;
 
-	test_init(argc, argv);
-
-	key = ftok(argv[0], 822155666);
+	key = ftok(filename, 822155666);
 	if (key == -1) {
 		err("Can't make key");
 		goto out;
 	}
 
-	shm = shmget(key, shmem_size, 0777 | IPC_CREAT | IPC_EXCL);
+	shm = prepare_shm(key, shmem_size);
 	if (shm == -1) {
-		err("Can't get shm");
 		fail_count++;
 		goto out;
 	}
 
-	mem = shmat(shm, NULL, 0);
-	if (mem == (void *)-1) {
-		err("Can't attach shm");
-		fail_count++;
-		goto out_shm;
-	}
-
-
 	test_daemon();
-
-	crc = INIT_CRC;
-	datagen(mem, shmem_size, &crc);
-	ret = shmdt(mem);
-	if (ret) {
-		err("Can't detach shm");
-		fail_count++;
-		goto out_shm;
-	}
-
 	test_waitsig();
 
-	mem = shmat(shm, NULL, 0);
-	if (mem == (void *)-1) {
-		err("Can't attach shm");
+	ret = check_shm_id(shm, shmem_size);
+	if (ret < 0) {
+		fail("ID check (1) failed\n");
 		fail_count++;
 		goto out_shm;
 	}
 
-	crc = INIT_CRC;
-	if (datachk(mem, shmem_size, &crc)) {
+	ret = check_shm_key(key, shmem_size);
+	if (ret < 0) {
+		fail("KEY check failed\n");
 		fail_count++;
-		fail("shmem data are corrupted");
+		goto out_shm;
 	}
 
-	shmdt(mem);
+	ret = shmctl(shm, IPC_RMID, NULL);
+	if (ret < 0) {
+		fail("Failed (1) to destroy segment: %d\n", -errno);
+		fail_count++;
+		goto out_shm;
+	}
+	/*
+	 * Code below checks that it's still possible to create new IPC SHM
+	 * segments
+	 */
+	shm = prepare_shm(key, shmem_size);
+	if (shm == -1) {
+		fail_count++;
+		goto out;
+	}
+
+	ret = check_shm_id(shm, shmem_size);
+	if (ret < 0) {
+		fail("ID check (2) failed\n");
+		fail_count++;
+		goto out_shm;
+	}
+
 out_shm:
-	shmctl(shm, IPC_RMID, NULL);
+	ret = shmctl(shm, IPC_RMID, NULL);
+	if (ret < 0) {
+		fail("Failed (2) to destroy segment: %d\n", -errno);
+		fail_count++;
+		goto out_shm;
+	}
 	if (fail_count == 0)
 		pass();
 out:
+	return;
+}
+
+
+int main(int argc, char **argv)
+{
+	filename = argv[0];
+#ifdef NEW_IPC_NS
+	test_init_ns(argc, argv, CLONE_NEWIPC, test_fn);
+#else
+	test_init(argc, argv);
+	test_fn();
+#endif
 	return 0;
 }


### PR DESCRIPTION
v2: cleanup issues fixed

What's new:
1) cloning to new IPC ns depends on built option.
2) Check for lookup shared segment by key added.
3) Check for creation new segnent after migration added.
4) Few check for syscalls results added.

Signed-off-by: Stanislav Kinsbursky skinsbursky@parallels.com
Signed-off-by: Andrey Vagin avagin@gmail.com
